### PR TITLE
Fix scientific notation in perf test

### DIFF
--- a/charts/fleet-manager-perf-test/templates/consumer-job.yaml
+++ b/charts/fleet-manager-perf-test/templates/consumer-job.yaml
@@ -29,13 +29,13 @@ spec:
             {{- if .consumerProperties }}
             printf "\n%s\n" "{{ .consumerProperties | nindent 12 | trim }}" >> /tmp/combined-client.properties
             {{- end }}
-            sleep {{ .startDelayMs }} && \
+            sleep {{ int .startDelayMs }} && \
             kafka-consumer-perf-test \
               --topic {{ $.Values.topic }} \
               --group {{ .name }} \
               --bootstrap-server {{ $.Values.bootstrapServer }} \
-              --messages {{ .numRecords }} \
-              --timeout {{ .timeoutMs }} \
+              --messages {{ int .numRecords }} \
+              --timeout {{ int .timeoutMs }} \
               --consumer.config /tmp/combined-client.properties | tee /tmp/consumer-perf-test-output.txt
 
             LAST_LINE=$(grep -v "^WARNING" /tmp/consumer-perf-test-output.txt | tail -n 1)
@@ -68,8 +68,8 @@ spec:
               "type": "Consumer",
               "name": "{{ .name }}",
               "config": {
-                "numRecords": {{ .numRecords }},
-                "timeoutMs": {{ .timeoutMs }}
+                "numRecords": {{ int .numRecords }},
+                "timeoutMs": {{ int .timeoutMs }}
               },
               "result": {
                 "startTime": "$START_TIME",

--- a/charts/fleet-manager-perf-test/templates/producer-job.yaml
+++ b/charts/fleet-manager-perf-test/templates/producer-job.yaml
@@ -41,9 +41,9 @@ spec:
               && \
             kafka-producer-perf-test \
               --topic {{ $.Values.topic }} \
-              --num-records {{ .numRecords }} \
-              --record-size {{ .recordSize }} \
-              --throughput {{ .throughput }} \
+              --num-records {{ int .numRecords }} \
+              --record-size {{ int .recordSize }} \
+              --throughput {{ int .throughput }} \
               --producer-props bootstrap.servers={{ $.Values.bootstrapServer }} \
               --producer.config /tmp/combined-client.properties | tee /tmp/perf-test-output.txt
             LAST_LINE=$(tail -n 1 /tmp/perf-test-output.txt)
@@ -64,9 +64,9 @@ spec:
               "type": "Producer",
               "name": "{{ .name }}",
               "config": {
-                "numRecords": {{ .numRecords }},
-                "recordSize": {{ .recordSize }},
-                "throughputConfig": {{ .throughput }}
+                "numRecords": {{ int .numRecords }},
+                "recordSize": {{ int .recordSize }},
+                "throughputConfig": {{ int .throughput }}
               },
               "result": {
                 "recordsSent": $RECORDS_SENT,


### PR DESCRIPTION
## Summary
- avoid scientific notation on large ints for perf test

## Testing
- `pre-commit` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68482146dd148328b4c10f2e635b5f67