### PR TITLE
fix perf-test chart for 4.0.0 with oauthbearer

### DIFF
--- a/charts/fleet-manager-perf-test/Chart.yaml
+++ b/charts/fleet-manager-perf-test/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: fleet-manager-perf-test
 description: Helm chart to run Kafka producer and consumer performance tests
-version: 0.7.2
+version: 0.7.3

--- a/charts/fleet-manager-perf-test/templates/consumer-job.yaml
+++ b/charts/fleet-manager-perf-test/templates/consumer-job.yaml
@@ -21,6 +21,12 @@ spec:
       containers:
       - name: consumer
         image: confluentinc/cp-kafka:latest
+        {{- $oauthMatch := regexFind `(?m)^sasl\.oauthbearer\.token\.endpoint\.url=.*$` $.Values.clientProperties }}
+        {{- if $oauthMatch }}
+        env:
+        - name: KAFKA_OPTS
+          value: "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{ trimPrefix \"sasl.oauthbearer.token.endpoint.url=\" $oauthMatch }}"
+        {{- end }}
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/fleet-manager-perf-test/templates/consumer-job.yaml
+++ b/charts/fleet-manager-perf-test/templates/consumer-job.yaml
@@ -25,7 +25,7 @@ spec:
         {{- if $oauthMatch }}
         env:
         - name: KAFKA_OPTS
-          value: "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{ trimPrefix \"sasl.oauthbearer.token.endpoint.url=\" $oauthMatch }}"
+          value: '-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{ trimPrefix "sasl.oauthbearer.token.endpoint.url=" $oauthMatch }}'
         {{- end }}
         command: ["/bin/bash", "-c"]
         args:

--- a/charts/fleet-manager-perf-test/templates/producer-job.yaml
+++ b/charts/fleet-manager-perf-test/templates/producer-job.yaml
@@ -21,6 +21,12 @@ spec:
       containers:
       - name: producer
         image: confluentinc/cp-kafka:latest
+        {{- $oauthMatch := regexFind `(?m)^sasl\.oauthbearer\.token\.endpoint\.url=.*$` $.Values.clientProperties }}
+        {{- if $oauthMatch }}
+        env:
+        - name: KAFKA_OPTS
+          value: "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{ trimPrefix \"sasl.oauthbearer.token.endpoint.url=\" $oauthMatch }}"
+        {{- end }}
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/fleet-manager-perf-test/templates/producer-job.yaml
+++ b/charts/fleet-manager-perf-test/templates/producer-job.yaml
@@ -25,7 +25,7 @@ spec:
         {{- if $oauthMatch }}
         env:
         - name: KAFKA_OPTS
-          value: "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{ trimPrefix \"sasl.oauthbearer.token.endpoint.url=\" $oauthMatch }}"
+          value: '-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{ trimPrefix "sasl.oauthbearer.token.endpoint.url=" $oauthMatch }}'
         {{- end }}
         command: ["/bin/bash", "-c"]
         args:


### PR DESCRIPTION
## Summary
- in fleet-manager-perf-test chart, add env var `KAFKA_OPTS` to producer and consumer jobs
- the env is only set when `clientProperties` defines `sasl.oauthbearer.token.endpoint.url`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e8c2edd948328b162755966e492fe