### PR TITLE
feat: make alertmanager optional

### DIFF
--- a/charts/fleet-manager-cfk-alerts/Chart.yaml
+++ b/charts/fleet-manager-cfk-alerts/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.4.2
+version: 0.5.0
 
 appVersion: "1.16.0"

--- a/charts/fleet-manager-cfk-alerts/templates/alertmanager-basic-auth-creds-secret.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/alertmanager-basic-auth-creds-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ stringData:
   kongCredType: basic-auth
   username: {{ .Values.alertmanager.username | default "fleetmanager-alerts" }}
   password: {{ .Values.alertmanager.password | default .Release.Namespace }}
+{{- end }}

--- a/charts/fleet-manager-cfk-alerts/templates/alertmanager-cert-secret.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/alertmanager-cert-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 {{- if and (empty .Values.certs.cert) (empty .Values.certManager.route53.hostedZoneID) }}
 {{- fail "Either .Values.certs.cert or .Values.certManager.route53.hostedZoneID must be set" -}}
 {{- end }}
@@ -23,4 +24,5 @@ data:
   ca.crt: {{ .Values.certs.cert | b64enc | quote }}
   tls.crt: {{ .Values.certs.cert | b64enc | quote }}
   tls.key: {{ .Values.certs.key | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/fleet-manager-cfk-alerts/templates/alertmanager-certificate.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/alertmanager-certificate.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.route53.hostedZoneID .Values.certManager.route53.region }}
+{{- if and .Values.alertmanager.enabled (and .Values.certManager.route53.hostedZoneID .Values.certManager.route53.region) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/fleet-manager-cfk-alerts/templates/alertmanager-config.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/alertmanager-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
@@ -66,6 +67,7 @@ spec:
 {{- end }}
 {{- if .http_config.bearer_token }}
             bearerToken: {{ .http_config.bearer_token | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fleet-manager-cfk-alerts/templates/alertmanager-ingress.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/alertmanager-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -20,3 +21,4 @@ spec:
                 port:
                   number: 9093
             pathType: ImplementationSpecific
+{{- end }}

--- a/charts/fleet-manager-cfk-alerts/templates/alertmanager-kong-consumer.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/alertmanager-kong-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
@@ -8,3 +9,4 @@ metadata:
 username: {{ .Values.alertmanager.username | default "fleetmanager-alerts" }}
 credentials:
 - alertmanager-basic-auth-creds
+{{- end }}

--- a/charts/fleet-manager-cfk-alerts/templates/alertmanager-kong-plugin.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/alertmanager-kong-plugin.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
 metadata:
@@ -6,3 +7,4 @@ metadata:
 plugin: basic-auth
 config:
   hide_credentials: true
+{{- end }}

--- a/charts/fleet-manager-cfk-alerts/templates/alertmanager.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/alertmanager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
@@ -8,3 +9,4 @@ spec:
   alertmanagerConfigSelector:
     matchLabels:
       alertmanagerConfig: {{ .Values.alertmanagerConfig.name }}
+{{- end }}

--- a/charts/fleet-manager-cfk-alerts/templates/cert-issuer.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/cert-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.route53.hostedZoneID .Values.certManager.route53.region }}
+{{- if and .Values.alertmanager.enabled (and .Values.certManager.route53.hostedZoneID .Values.certManager.route53.region) }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/charts/fleet-manager-cfk-alerts/templates/route53-credentials-secret.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/route53-credentials-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.route53.accessKeyID .Values.certManager.route53.secretAccessKey }}
+{{- if and .Values.alertmanager.enabled (and .Values.certManager.route53.accessKeyID .Values.certManager.route53.secretAccessKey) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/fleet-manager-cfk-alerts/templates/slack-api-url-secret.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/slack-api-url-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 {{- range .Values.alertmanagerConfig.receivers }}
 {{- if eq .receiver_type "slack" }}
 ---
@@ -8,6 +9,7 @@ metadata:
 stringData:
   api-url: {{ .api_url | quote }}
 type: Opaque
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/fleet-manager-cfk-alerts/values.schema.json
+++ b/charts/fleet-manager-cfk-alerts/values.schema.json
@@ -5,12 +5,19 @@
     "alertmanager": {
       "type": "object",
       "properties": {
+        "enabled": { "type": "boolean", "default": true },
         "name": { "type": "string" },
         "replicas": { "type": "integer" },
         "username": { "type": "string", "default": "fleetmanager-alerts" },
         "password": { "type": "string" }
       },
-      "required": ["name", "replicas"],
+      "required": ["enabled"],
+      "allOf": [
+        {
+          "if": { "properties": { "enabled": { "const": true } } },
+          "then": { "required": ["name", "replicas"] }
+        }
+      ],
       "additionalProperties": false
     },
     "alertmanagerConfig": {

--- a/charts/fleet-manager-cfk-alerts/values.yaml
+++ b/charts/fleet-manager-cfk-alerts/values.yaml
@@ -1,4 +1,5 @@
 alertmanager:
+  enabled: true
   name:
   replicas: 1
   username: fleetmanager-alerts

--- a/charts/fleet-manager-strimzi-alerts/Chart.yaml
+++ b/charts/fleet-manager-strimzi-alerts/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.3.2
+version: 0.4.0
 
 appVersion: "1.16.0"

--- a/charts/fleet-manager-strimzi-alerts/templates/alertmanager-basic-auth-creds-secret.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/alertmanager-basic-auth-creds-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ stringData:
   kongCredType: basic-auth
   username: {{ .Values.alertmanager.username | default "fleetmanager-alerts" }}
   password: {{ .Values.alertmanager.password | default .Release.Namespace }}
+{{- end }}

--- a/charts/fleet-manager-strimzi-alerts/templates/alertmanager-cert-secret.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/alertmanager-cert-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 {{- if and (empty .Values.certs.cert) (empty .Values.certManager.route53.hostedZoneID) }}
 {{- fail "Either .Values.certs.cert or .Values.certManager.route53.hostedZoneID must be set" -}}
 {{- end }}
@@ -23,4 +24,5 @@ data:
   ca.crt: {{ .Values.certs.cert | b64enc | quote }}
   tls.crt: {{ .Values.certs.cert | b64enc | quote }}
   tls.key: {{ .Values.certs.key | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/fleet-manager-strimzi-alerts/templates/alertmanager-certificate.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/alertmanager-certificate.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.route53.hostedZoneID .Values.certManager.route53.region }}
+{{- if and .Values.alertmanager.enabled (and .Values.certManager.route53.hostedZoneID .Values.certManager.route53.region) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/fleet-manager-strimzi-alerts/templates/alertmanager-config.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/alertmanager-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
@@ -66,6 +67,7 @@ spec:
 {{- end }}
 {{- if .http_config.bearer_token }}
             bearerToken: {{ .http_config.bearer_token | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fleet-manager-strimzi-alerts/templates/alertmanager-ingress.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/alertmanager-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -20,3 +21,4 @@ spec:
                 port:
                   number: 9093
             pathType: ImplementationSpecific
+{{- end }}

--- a/charts/fleet-manager-strimzi-alerts/templates/alertmanager-kong-consumer.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/alertmanager-kong-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
@@ -8,3 +9,4 @@ metadata:
 username: {{ .Values.alertmanager.username | default "fleetmanager-alerts" }}
 credentials:
 - alertmanager-basic-auth-creds
+{{- end }}

--- a/charts/fleet-manager-strimzi-alerts/templates/alertmanager-kong-plugin.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/alertmanager-kong-plugin.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
 metadata:
@@ -6,3 +7,4 @@ metadata:
 plugin: basic-auth
 config:
   hide_credentials: true
+{{- end }}

--- a/charts/fleet-manager-strimzi-alerts/templates/alertmanager.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/alertmanager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
@@ -8,3 +9,4 @@ spec:
   alertmanagerConfigSelector:
     matchLabels:
       alertmanagerConfig: {{ .Values.alertmanagerConfig.name }}
+{{- end }}

--- a/charts/fleet-manager-strimzi-alerts/templates/cert-issuer.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/cert-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.route53.hostedZoneID .Values.certManager.route53.region }}
+{{- if and .Values.alertmanager.enabled (and .Values.certManager.route53.hostedZoneID .Values.certManager.route53.region) }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/charts/fleet-manager-strimzi-alerts/templates/route53-credentials-secret.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/route53-credentials-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.route53.accessKeyID .Values.certManager.route53.secretAccessKey }}
+{{- if and .Values.alertmanager.enabled (and .Values.certManager.route53.accessKeyID .Values.certManager.route53.secretAccessKey) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/fleet-manager-strimzi-alerts/templates/slack-api-url-secret.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/slack-api-url-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 {{- range .Values.alertmanagerConfig.receivers }}
 {{- if eq .receiver_type "slack" }}
 ---
@@ -8,6 +9,7 @@ metadata:
 stringData:
   api-url: {{ .api_url | quote }}
 type: Opaque
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/fleet-manager-strimzi-alerts/values.schema.json
+++ b/charts/fleet-manager-strimzi-alerts/values.schema.json
@@ -5,12 +5,19 @@
     "alertmanager": {
       "type": "object",
       "properties": {
+        "enabled": { "type": "boolean", "default": true },
         "name": { "type": "string" },
         "replicas": { "type": "integer" },
         "username": { "type": "string", "default": "fleetmanager-alerts" },
         "password": { "type": "string" }
       },
-      "required": ["name", "replicas"],
+      "required": ["enabled"],
+      "allOf": [
+        {
+          "if": { "properties": { "enabled": { "const": true } } },
+          "then": { "required": ["name", "replicas"] }
+        }
+      ],
       "additionalProperties": false
     },
     "alertmanagerConfig": {

--- a/charts/fleet-manager-strimzi-alerts/values.yaml
+++ b/charts/fleet-manager-strimzi-alerts/values.yaml
@@ -1,4 +1,5 @@
 alertmanager:
+  enabled: true
   name:
   replicas: 1
   username: fleetmanager-alerts


### PR DESCRIPTION
## Summary
- make AlertManager resources optional via `alertmanager.enabled`
- bump `fleet-manager-cfk-alerts` chart to 0.5.0 and `fleet-manager-strimzi-alerts` to 0.4.0

## Testing
- `helm lint charts/fleet-manager-cfk-alerts` *(fails: command not found: helm)*
- `helm lint charts/fleet-manager-strimzi-alerts` *(fails: command not found: helm)*


------
https://chatgpt.com/codex/tasks/task_b_68909b24f6248329b9293a2a0df772ff