### PR TITLE
feat: add alertmanager ingress

### DIFF
--- a/charts/fleet-manager-infra-shared/Chart.yaml
+++ b/charts/fleet-manager-infra-shared/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.2.4
+version: 0.3.0
 
 appVersion: "0.0.0"

--- a/charts/fleet-manager-infra-shared/templates/alertmanager-basic-auth-creds-secret.yaml
+++ b/charts/fleet-manager-infra-shared/templates/alertmanager-basic-auth-creds-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-basic-auth-creds
+  namespace: {{ .Values.prometheus.namespace }}
+  labels:
+    konghq.com/credential: basic-auth
+stringData:
+  kongCredType: basic-auth
+  username: {{ .Values.alertmanager.username }}
+  password: {{ .Values.alertmanager.password }}
+

--- a/charts/fleet-manager-infra-shared/templates/alertmanager-ingress.yaml
+++ b/charts/fleet-manager-infra-shared/templates/alertmanager-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alertmanager-ingress
+  namespace: {{ .Values.prometheus.namespace }}
+  annotations:
+    konghq.com/plugins: monitoring-basic-auth
+spec:
+  ingressClassName: kong
+  tls:
+  - secretName: monitoring-tls
+    hosts:
+    - {{ .Values.alertmanager.hostname }}
+  rules:
+    - host: {{ .Values.alertmanager.hostname }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: {{ .Values.alertmanager.service }}
+                port:
+                  number: 9093
+            pathType: ImplementationSpecific

--- a/charts/fleet-manager-infra-shared/templates/alertmanager-kong-consumer.yaml
+++ b/charts/fleet-manager-infra-shared/templates/alertmanager-kong-consumer.yaml
@@ -1,0 +1,11 @@
+apiVersion: configuration.konghq.com/v1
+kind: KongConsumer
+metadata:
+  name: alertmanager-basic-auth
+  namespace: {{ .Values.prometheus.namespace }}
+  annotations:
+    kubernetes.io/ingress.class: kong
+username: {{ .Values.alertmanager.username }}
+credentials:
+- alertmanager-basic-auth-creds
+

--- a/charts/fleet-manager-infra-shared/templates/monitoring-certificate.yaml
+++ b/charts/fleet-manager-infra-shared/templates/monitoring-certificate.yaml
@@ -8,6 +8,7 @@ spec:
   commonName: {{ .Values.domain }}
   dnsNames:
   - {{ .Values.prometheus.hostname }}
+  - {{ .Values.alertmanager.hostname }}
   - {{ .Values.loki.hostname }}
   issuerRef:
     kind: ClusterIssuer

--- a/charts/fleet-manager-infra-shared/values.yaml
+++ b/charts/fleet-manager-infra-shared/values.yaml
@@ -8,13 +8,18 @@ opencost:
   service: kafka-fleet-manager-opencost
   namespace: opencost
 prometheus:
-  hostname: 
-  username: 
-  password: 
+  hostname:
+  username:
+  password:
   service: kafka-fleet-manager-promet-prometheus
   namespace: monitoring
+alertmanager:
+  hostname:
+  username:
+  password:
+  service: kafka-fleet-manager-promet-alertmanager
 loki:
-  hostname: 
+  hostname:
   service: kafka-fleet-manager-loki-gateway
 strimzi:
   namespace: strimzi


### PR DESCRIPTION
## Summary
- expose AlertManager through Kong ingress
- include AlertManager host in monitoring TLS certificate
- secure AlertManager with dedicated basic-auth credentials

## Testing
- `curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash` *(fails: Failed to install helm)*
- `apt-get install -y helm` *(fails: Unable to locate package helm)*
- `helm lint charts/fleet-manager-infra-shared` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68909fc2e96483299097bfec0eacbeb1