### PR TITLE
infra-shared: add AlertmanagerConfig

### DIFF
--- a/charts/fleet-manager-infra-shared/Chart.yaml
+++ b/charts/fleet-manager-infra-shared/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.3.1
+version: 0.4.0
 
 appVersion: "0.0.0"

--- a/charts/fleet-manager-infra-shared/templates/alertmanager-config.yaml
+++ b/charts/fleet-manager-infra-shared/templates/alertmanager-config.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.alertmanagerConfig.name }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: {{ .Values.alertmanagerConfig.name }}
+  labels:
+    alertmanagerConfig: {{ .Values.alertmanagerConfig.name }}
+spec:
+  route:
+    receiver: "webhook"
+{{- if .Values.alertmanagerConfig.receivers }}
+    routes:
+{{- range .Values.alertmanagerConfig.receivers }}
+      - receiver: {{ .name | quote }}
+        continue: true
+{{- end }}
+{{- end }}
+    matchers:
+      - name: cluster
+        value: {{ .Release.Namespace }}
+        matchType: "="
+  receivers:
+    - name: "webhook"
+      webhookConfigs:
+        - url: {{ .Values.alertmanagerConfig.webhookUrl | quote }}
+          sendResolved: true
+{{- range .Values.alertmanagerConfig.receivers }}
+    - name: {{ .name | quote }}
+{{- if eq .receiver_type "slack" }}
+      slackConfigs:
+        - channel: {{ .channel | quote }}
+          apiURL:
+            name: {{ printf "%s-%s-slack" $.Values.alertmanagerConfig.name .name | quote }}
+            key: api-url
+          sendResolved: true
+          username: StreamTime AlertManager for {{ $.Release.Namespace }}
+{{- else if eq .receiver_type "pagerduty" }}
+      pagerdutyConfigs:
+        - routingKey: {{ .routing_key | quote }}
+          sendResolved: true
+{{- if .url }}
+          url: {{ .url | quote }}
+{{- end }}
+{{- if .client }}
+          client: {{ .client | quote }}
+{{- end }}
+{{- if .client_url }}
+          clientURL: {{ .client_url | quote }}
+{{- end }}
+{{- else if eq .receiver_type "webhook" }}
+      webhookConfigs:
+        - url: {{ .url | quote }}
+          sendResolved: true
+{{- if .http_config }}
+          httpConfig:
+{{- if .http_config.proxy_url }}
+            proxyURL: {{ .http_config.proxy_url | quote }}
+{{- end }}
+{{- if .http_config.basic_auth }}
+            basicAuth:
+{{- if .http_config.basic_auth.username }}
+              username: {{ .http_config.basic_auth.username | quote }}
+{{- end }}
+{{- if .http_config.basic_auth.password }}
+              password: {{ .http_config.basic_auth.password | quote }}
+{{- end }}
+{{- end }}
+{{- if .http_config.bearer_token }}
+            bearerToken: {{ .http_config.bearer_token | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/fleet-manager-infra-shared/templates/slack-api-url-secret.yaml
+++ b/charts/fleet-manager-infra-shared/templates/slack-api-url-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.alertmanagerConfig.name }}
+{{- range .Values.alertmanagerConfig.receivers }}
+{{- if eq .receiver_type "slack" }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s-slack" $.Values.alertmanagerConfig.name .name }}
+stringData:
+  api-url: {{ .api_url | quote }}
+type: Opaque
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/fleet-manager-infra-shared/values.yaml
+++ b/charts/fleet-manager-infra-shared/values.yaml
@@ -18,6 +18,10 @@ alertmanager:
   username:
   password:
   service: kafka-fleet-manager-promet-alertmanager
+alertmanagerConfig:
+  name:
+  webhookUrl:
+  receivers: []
 loki:
   hostname:
   service: kafka-fleet-manager-loki-gateway


### PR DESCRIPTION
## Summary
- add optional AlertmanagerConfig with same inputs as other alert charts
- generate Slack API URL secret for Slack receivers
- bump fleet-manager-infra-shared chart to v0.4.0

## Testing
- `helm lint charts/fleet-manager-infra-shared --set alertmanagerConfig.name=test --set alertmanagerConfig.webhookUrl=https://example.com` *(fails: helm not installed)*
- `curl -L https://get.helm.sh/helm-v3.13.0-linux-amd64.tar.gz -o helm.tar.gz` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_b_6894502b289083298ea18ed9c9dc3736