### PR TITLE
Add external DNS annotations to ingress resources

### DIFF
--- a/charts/fleet-manager-cfk-alerts/Chart.yaml
+++ b/charts/fleet-manager-cfk-alerts/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.5.1
+version: 0.6.0
 
 appVersion: "1.16.0"

--- a/charts/fleet-manager-cfk-alerts/templates/alertmanager-ingress.yaml
+++ b/charts/fleet-manager-cfk-alerts/templates/alertmanager-ingress.yaml
@@ -5,6 +5,8 @@ metadata:
   name: alertmanager-ingress
   annotations:
     konghq.com/plugins: alertmanager-basic-auth
+    external-dns.alpha.kubernetes.io/hostname: {{ printf "alerts-%s.%s" .Release.Namespace .Values.domain }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: kong
   tls:

--- a/charts/fleet-manager-cfk/Chart.yaml
+++ b/charts/fleet-manager-cfk/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.17.1
+version: 0.18.0
 
 appVersion: "0.0.0"

--- a/charts/fleet-manager-cfk/templates/control-center-ingress.yaml
+++ b/charts/fleet-manager-cfk/templates/control-center-ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: controlcenter
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: cc-{{ .Release.Namespace }}.{{ .Values.domain }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: {{ .Values.ingressClassName }}
   tls:

--- a/charts/fleet-manager-cfk/templates/kafka-ingress.yaml
+++ b/charts/fleet-manager-cfk/templates/kafka-ingress.yaml
@@ -8,6 +8,8 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     ingress.kubernetes.io/ssl-passthrough: "true"
+    external-dns.alpha.kubernetes.io/hostname: {{- range $i, $e := until (.Values.replicas | int) -}}{{ if $i }},{{ end }}{{ $.Release.Namespace }}-b{{ $e }}.{{ $.Values.domain }}{{- end }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: {{ .Release.Namespace }}
   tls:

--- a/charts/fleet-manager-cfk/templates/mds-ingress.yaml
+++ b/charts/fleet-manager-cfk/templates/mds-ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mds
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: mds-{{ .Release.Namespace }}.{{ .Values.domain }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: {{ .Release.Namespace }}
   tls:

--- a/charts/fleet-manager-cfk/templates/schema-registry-ingress.yaml
+++ b/charts/fleet-manager-cfk/templates/schema-registry-ingress.yaml
@@ -3,6 +3,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: schema-registry
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: schema-{{ .Release.Namespace }}.{{ .Values.domain }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: {{ .Release.Namespace }}
   tls:

--- a/charts/fleet-manager-infra-shared/Chart.yaml
+++ b/charts/fleet-manager-infra-shared/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.4.1
+version: 0.5.0
 
 appVersion: "0.0.0"

--- a/charts/fleet-manager-infra-shared/templates/alertmanager-ingress.yaml
+++ b/charts/fleet-manager-infra-shared/templates/alertmanager-ingress.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.prometheus.namespace }}
   annotations:
     konghq.com/plugins: monitoring-basic-auth
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.alertmanager.hostname }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: kong
   tls:

--- a/charts/fleet-manager-infra-shared/templates/loki-ingress.yaml
+++ b/charts/fleet-manager-infra-shared/templates/loki-ingress.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.prometheus.namespace }}
   annotations:
     konghq.com/plugins: monitoring-basic-auth
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.loki.hostname }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: kong
   tls:

--- a/charts/fleet-manager-infra-shared/templates/opencost-ingress.yaml
+++ b/charts/fleet-manager-infra-shared/templates/opencost-ingress.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.opencost.namespace }}
   annotations:
     konghq.com/plugins: opencost-basic-auth
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.opencost.hostname }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: kong
   tls:

--- a/charts/fleet-manager-infra-shared/templates/prometheus-ingress.yaml
+++ b/charts/fleet-manager-infra-shared/templates/prometheus-ingress.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.prometheus.namespace }}
   annotations:
     konghq.com/plugins: monitoring-basic-auth
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.prometheus.hostname }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: kong
   tls:

--- a/charts/fleet-manager-org-ingress/Chart.yaml
+++ b/charts/fleet-manager-org-ingress/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for Kafka Fleet Manager Organization Ingress
 
 type: application
 
-version: 0.1.1
+version: 0.2.0
 

--- a/charts/fleet-manager-org-ingress/templates/api-ingress.yaml
+++ b/charts/fleet-manager-org-ingress/templates/api-ingress.yaml
@@ -6,6 +6,8 @@ metadata:
     konghq.com/plugins: {{ .Values.fleetmanager.org }}-jwt, cors
     cert-manager.io/cluster-issuer: letsencrypt-prod
     konghq.com/regex-priority: "9"
+    external-dns.alpha.kubernetes.io/hostname: {{ include "fleetmanager.api.domain" . }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
     # kubernetes.io/ingress.class: kong
 spec:
   ingressClassName: kong

--- a/charts/fleet-manager-redpanda/Chart.yaml
+++ b/charts/fleet-manager-redpanda/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.4.0
+version: 0.5.0
 
 appVersion: "0.0.0"
 

--- a/charts/fleet-manager-redpanda/templates/admin-api-ingress.yaml
+++ b/charts/fleet-manager-redpanda/templates/admin-api-ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: redpanda-admin
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: rp-admin-{{ .Release.Namespace }}.{{ .Values.redpanda.external.domain }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: {{ .Release.Namespace }}
   tls:

--- a/charts/fleet-manager-redpanda/templates/console-ingress.yaml
+++ b/charts/fleet-manager-redpanda/templates/console-ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: redpanda-console
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: rp-console-{{ .Release.Namespace }}.{{ .Values.redpanda.external.domain }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: {{ .Values.ingressClassName }}
   tls:

--- a/charts/fleet-manager-redpanda/templates/kafka-ingress.yaml
+++ b/charts/fleet-manager-redpanda/templates/kafka-ingress.yaml
@@ -7,6 +7,8 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     ingress.kubernetes.io/ssl-passthrough: "true"
+    external-dns.alpha.kubernetes.io/hostname: {{- range $i, $e := until (.Values.redpanda.statefulset.replicas | int) -}}{{ if $i }},{{ end }}{{ $.Release.Namespace }}-rp-{{ $e }}.{{ $.Values.redpanda.external.domain }}{{- end }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: {{ .Release.Namespace }}
   tls:

--- a/charts/fleet-manager-redpanda/templates/schema-registry-ingress.yaml
+++ b/charts/fleet-manager-redpanda/templates/schema-registry-ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: redpanda-schema-registry
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: rp-schema-{{ .Release.Namespace }}.{{ .Values.redpanda.external.domain }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: {{ .Release.Namespace }}
   tls:

--- a/charts/fleet-manager-strimzi-alerts/Chart.yaml
+++ b/charts/fleet-manager-strimzi-alerts/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.4.1
+version: 0.5.0
 
 appVersion: "1.16.0"

--- a/charts/fleet-manager-strimzi-alerts/templates/alertmanager-ingress.yaml
+++ b/charts/fleet-manager-strimzi-alerts/templates/alertmanager-ingress.yaml
@@ -5,6 +5,8 @@ metadata:
   name: alertmanager-ingress
   annotations:
     konghq.com/plugins: alertmanager-basic-auth
+    external-dns.alpha.kubernetes.io/hostname: {{ printf "alerts-%s.%s" .Release.Namespace .Values.domain }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: kong
   tls:

--- a/charts/fleet-manager-warpstream/Chart.yaml
+++ b/charts/fleet-manager-warpstream/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.0
+version: 0.2.0
 
 appVersion: "0.0.0"
 

--- a/charts/fleet-manager-warpstream/templates/kafka-ingress.yaml
+++ b/charts/fleet-manager-warpstream/templates/kafka-ingress.yaml
@@ -7,6 +7,8 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     ingress.kubernetes.io/ssl-passthrough: "true"
+    external-dns.alpha.kubernetes.io/hostname: {{- range $i, $e := until (.Values.warpstream.replicas | int) -}}{{ if $i }},{{ end }}{{ $.Release.Namespace }}-ws-{{ $e }}.{{ $.Values.warpstream.statefulSetConfig.clusterDomain }}{{- end }}
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   ingressClassName: {{ .Release.Namespace }}
   tls:


### PR DESCRIPTION
## Summary
- annotate all ingress templates with external-dns hostname and TTL
- bump minor versions of affected charts

## Testing
- `helm lint charts/fleet-manager-strimzi-alerts` *(fails: command not found)*
- `apt-get install -y helm` *(fails: Unable to locate package helm)*

------
https://chatgpt.com/codex/tasks/task_b_689dce8b9dc0832992c70fb59c3df461